### PR TITLE
Made README cleaner

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,26 +113,19 @@ Or if you use a lua config file such as `~/.config/nvim/init.lua`, you can put:
 ```lua
 -- set shorter name for keymap function
 local kmap = vim.keymap.set
+local knap = require("knap")
 
 -- F5 processes the document once, and refreshes the view
-kmap('i','<F5>', function() require("knap").process_once() end)
-kmap('v','<F5>', function() require("knap").process_once() end)
-kmap('n','<F5>', function() require("knap").process_once() end)
+kmap({ 'n', 'v', 'i' },'<F5>', knap.process_once)
 
 -- F6 closes the viewer application, and allows settings to be reset
-kmap('i','<F6>', function() require("knap").close_viewer() end)
-kmap('v','<F6>', function() require("knap").close_viewer() end)
-kmap('n','<F6>', function() require("knap").close_viewer() end)
+kmap({ 'n', 'v', 'i' },'<F6>', knap.close_viewer)
 
 -- F7 toggles the auto-processing on and off
-kmap('i','<F7>', function() require("knap").toggle_autopreviewing() end)
-kmap('v','<F7>', function() require("knap").toggle_autopreviewing() end)
-kmap('n','<F7>', function() require("knap").toggle_autopreviewing() end)
+kmap({ 'n', 'v', 'i' },'<F7>', knap.toggle_autopreviewing)
 
 -- F8 invokes a SyncTeX forward search, or similar, where appropriate
-kmap('i','<F8>', function() require("knap").forward_jump() end)
-kmap('v','<F8>', function() require("knap").forward_jump() end)
-kmap('n','<F8>', function() require("knap").forward_jump() end)
+kmap({ 'n', 'v', 'i' },'<F8>', knap.forward_jump)
 ```
 
 Of course, feel free to choose other keys in place of <kbd>F5</kbd>-<kbd>F8</kbd>.


### PR DESCRIPTION
This makes the lua keymap section cleaner.
If you didn't know the first parameter to the `vim.keymap.set` function can either be a string (e.g: 'n' or 'v'...) and it can be a table in case you want to use the same keymap in multiple modes this changes turns 3 lines of code to one.
And since you're already using a variable for `vim.keymap.set` you mite as well use one for `require("knap")`.
And lastly the 3rd parameter of `vim.key.set` i.e the command to run doesn't need to be in the function () end format in this case, it only makes sense to use that format if you're passing a parameter to the function (e.g: `knap.open(This file)` if you're doing something like this then sure), but here you only want to call the function so you can just index it i.e just put the function name without the `()` at the end and nvim will call it for you.
All of these don't change the functionality but make the keymaps look better and shorter.