### PR TITLE
Fix typo at Sioyek configuration at README

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ Since it is default, you need not put these settings in your `init.vim` unless y
 
 ```vimscript
 let g:knap_settings = {
-    \ "textopdfviewerlaunch": "sioyek --inverse-search 'nvim --headless -es --cmd \"lua require('\"'\"'knaphelper'\"'\"').relayjump('\"'\"'%servername%'\"'\"','\"'\"'%1'\"'\"',%2,0)\"' --new-windoow %outputfile%",
+    \ "textopdfviewerlaunch": "sioyek --inverse-search 'nvim --headless -es --cmd \"lua require('\"'\"'knaphelper'\"'\"').relayjump('\"'\"'%servername%'\"'\"','\"'\"'%1'\"'\"',%2,0)\"' --new-window %outputfile%",
     \ "textopdfviewerrefresh": "none",
     \ "textopdfforwardjump": "sioyek --inverse-search 'nvim --headless -es --cmd \"lua require('\"'\"'knaphelper'\"'\"').relayjump('\"'\"'%servername%'\"'\"','\"'\"'%1'\"'\"',%2,0)\"' --reuse-window --forward-search-file %srcfile% --forward-search-line %line% %outputfile%"
 }


### PR DESCRIPTION
Correct `--new-windoow` to `--new-window`.