### PR TITLE
Corrected for strange behavior

### DIFF
--- a/llpp/synctex-inverse.lua
+++ b/llpp/synctex-inverse.lua
@@ -92,5 +92,8 @@ proc:close()
 local cmd = 'nvim --headless -es --cmd "lua require(\'knaphelper\')' ..
     '.relayjump(\'all\',\'' .. infile .. '\',' .. linenum .. ','
     .. col .. ')"'
-local _,_,succ = os.execute(cmd)
+local succ,_,ret = os.execute(cmd)
+if (tonumber(succ) == nil) then
+    os.exit(ret)
+end
 os.exit(succ)

--- a/lua/knap.lua
+++ b/lua/knap.lua
@@ -135,7 +135,7 @@ function close_viewer()
         local waskilled = os.execute('pkill -P ' ..
             tostring(vim.b.knap_viewerpid) .. ' > /dev/null 2>&1')
         -- above returns exit code of kill command
-        if not (waskilled) then
+        if not (waskilled == true or waskilled == 0) then
             err_msg("Could not kill process " ..
                 tostring(vim.b.knap_viewerpid))
         end
@@ -219,7 +219,7 @@ function forward_jump()
     end
     local result = os.execute(fjprecmd .. fjcmd .. ' > /dev/null 2>&1')
     -- report if error
-    if not (result) then
+    if not (result == true or result == 0) then
         err_msg("Jump command not successful. (Cmd: " .. fjcmd .. ")")
     end
 end
@@ -290,7 +290,7 @@ end
 function is_running(pid)
     -- use ps to see if process is active
     local running = os.execute('ps -p ' .. tostring(pid) .. ' > /dev/null 2>&1')
-    if (running) then
+    if (running == true or running == 0) then
         return true
     end
     if not (vim.b.knap_viewer_launch_cmd) then
@@ -301,7 +301,7 @@ function is_running(pid)
     procname = procname:gsub('.*&&%s*','')
     procname = procname:gsub('%s.*','')
     running = os.execute('pgrep "' .. procname .. '" > /dev/null 2>&1')
-    return running
+    return (running == true or running == 0)
 end
 
 -- move the cursor to a location if the file requested is the current
@@ -460,7 +460,7 @@ function refresh_viewer()
     end
     local succ = os.execute(rcmd)
     -- report if error
-    if not (succ) then
+    if not (succ == true or succ == 0) then
         err_msg('Error when attempting to refresh viewer.')
     end
 end


### PR DESCRIPTION
My original correction of `os.execute` was based on the fact that on my system (fedora) it returned as per the 5.2+ docs, but it is supposed to (and normally does) return as specified in the 5.1- docs. This patch works in both situations. I believe the strange behavior to be an issue with the fedora package of neovim, but it may be present elsewhere.